### PR TITLE
Add Google Search Grounding helper and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,54 @@ View your app in AI Studio: https://ai.studio/apps/drive/1U-U3t01354eboQIODrLozK
 
 ## Run Locally
 
-**Prerequisites:**  Node.js
+**Prerequisites:** Node.js for the web client and Python 3.11+ for the CLI helpers.
 
+### Front-end
 
-1. Install dependencies:
-   `npm install`
+1. Install dependencies: `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+3. Run the app: `npm run dev`
+
+### Python tooling & demos
+
+1. Install Python dependencies: `pip install -r requirements.txt`
+2. Export your Gemini API key in the current shell before running scripts:
+   ```bash
+   export GEMINI_API_KEY="your_gemini_api_key"
+   ```
+3. Run the end-to-end demo: `python main.py`
+
+## Configuration & Services
+
+### Gemini / Google API key setup
+
+1. Visit [Google AI Studio](https://aistudio.google.com/).
+2. Create or reuse an API key with access to Gemini 1.5 models and Google Search Grounding.
+3. Copy the key and either:
+   * Place it in `.env.local` (front-end) or `.env` (if you maintain one for Python), **and**
+   * Export it as an environment variable for Python scripts:
+     ```bash
+     export GEMINI_API_KEY="your_gemini_api_key"
+     ```
+4. Restart your terminal or re-run the export whenever the variable is missing. The Python demo prints actionable errors if the key is not detected or is invalid.
+
+### Google Search Grounding prerequisites
+
+* Ensure the API key you generated above has the *Google Search Grounding* add-on enabled in Google AI Studio. Without this entitlement the demo call will fail with an authentication error.
+* `google-generativeai` (installed via `requirements.txt`) is required. Keep it updated to the latest release to receive the Grounding client APIs.
+* Network access to `generativelanguage.googleapis.com` must be allowed.
+
+### Local Ollama embedding service
+
+1. [Install Ollama](https://ollama.com/) on your machine.
+2. Pull the embedding model used by this repo:
+   ```bash
+   ollama pull dengcao/Qwen3-Embedding-8B:Q4_K_M
+   ```
+3. Start the Ollama server (if not already running):
+   ```bash
+   ollama serve
+   ```
+4. By default the embedding script expects Ollama at `http://localhost:11434`. Update `src/embedding_client.py` if you host it elsewhere.
+
+When either Ollama or Google services are unreachable the Python utilities emit explicit guidance to help you troubleshoot network connectivity or missing configuration.

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 import json
 import numpy as np
 
+from src.grounding_search import GroundingSearchError, search_google_grounding
 from src.strategy_architect import generate_strategic_blueprint
 from src.embedding_client import embed_strategies
 from src.diversity_calculator import calculate_similarity_matrix
@@ -10,6 +11,32 @@ from src.diversity_calculator import calculate_similarity_matrix
 def main():
     """Run the end-to-end test pipeline for strategy generation and analysis."""
     print("--- Running Full Pipeline Test Script (Gemini + Ollama) ---")
+
+    print("\n--- Grounding Search Demo (Google Search Grounding) ---")
+    grounding_metadata_for_reference = None
+    try:
+        search_demo = search_google_grounding(
+            "Gemini 1.5 Flash 最新能力更新", top_k=3
+        )
+    except GroundingSearchError as error:
+        print("[GROUNDING ERROR] Could not run Google Search Grounding demo.")
+        print(error)
+        print(
+            "Please ensure GEMINI_API_KEY is configured and that your network allows "
+            "outbound access to Google APIs."
+        )
+    else:
+        print("Grounding results:")
+        print(json.dumps(search_demo["results"], indent=2, ensure_ascii=False))
+        grounding_metadata_for_reference = search_demo.get("grounding_metadata")
+        if isinstance(grounding_metadata_for_reference, dict):
+            chunk_count = len(grounding_metadata_for_reference.get("grounding_chunks", []))
+        else:
+            chunk_count = 0
+        print(
+            "Stored raw grounding metadata for future use "
+            f"({chunk_count} grounding chunks captured)."
+        )
 
     # Ensure the Gemini API key is available before attempting generation.
     if not os.environ.get("GEMINI_API_KEY"):

--- a/src/grounding_search.py
+++ b/src/grounding_search.py
@@ -1,0 +1,161 @@
+"""Utility helpers for Google Search Grounding."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+import google.generativeai as genai
+from google.api_core import exceptions as google_exceptions
+from google.generativeai import client
+from google.generativeai.client import glm
+
+
+DEFAULT_GROUNDED_MODEL = "models/gemini-1.5-flash"
+
+
+class GroundingSearchError(RuntimeError):
+    """Raised when Google Search Grounding fails."""
+
+
+def _ensure_api_key() -> str:
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        raise GroundingSearchError(
+            "GEMINI_API_KEY environment variable is not set. "
+            "Please export your Gemini API key before calling Google Search Grounding."
+        )
+    return api_key
+
+
+def _configure_clients(api_key: str) -> client.glm.GenerativeServiceClient:
+    # Configure both the high-level module and the lower-level GAPIC client.
+    genai.configure(api_key=api_key)
+    client.configure(api_key=api_key)
+    return client.get_default_generative_client()
+
+
+def _extract_results(
+    metadata: Optional[glm.GroundingMetadata], top_k: Optional[int]
+) -> List[Dict[str, str]]:
+    if not metadata:
+        return []
+
+    chunk_results: Dict[int, Dict[str, str]] = {}
+    for index, chunk in enumerate(metadata.grounding_chunks):
+        web_chunk = chunk.web
+        if not web_chunk:
+            continue
+        chunk_results[index] = {
+            "title": web_chunk.title or "",
+            "url": web_chunk.uri or "",
+            "snippet": "",
+        }
+
+    if not chunk_results:
+        return []
+
+    for support in metadata.grounding_supports:
+        segment = support.segment
+        if not segment or not segment.text:
+            continue
+        snippet_text = segment.text.strip()
+        if not snippet_text:
+            continue
+        for chunk_index in support.grounding_chunk_indices:
+            item = chunk_results.get(chunk_index)
+            if not item:
+                continue
+            if item["snippet"]:
+                if snippet_text not in item["snippet"]:
+                    item["snippet"] = f"{item['snippet']} {snippet_text}".strip()
+            else:
+                item["snippet"] = snippet_text
+
+    ordered_results = [chunk_results[index] for index in sorted(chunk_results.keys())]
+
+    for entry in ordered_results:
+        entry["snippet"] = entry["snippet"].strip()
+
+    if top_k is not None and top_k > 0:
+        return ordered_results[:top_k]
+    return ordered_results
+
+
+def search_google_grounding(
+    query: str, *, top_k: Optional[int] = None, model: str = DEFAULT_GROUNDED_MODEL
+) -> Dict[str, Any]:
+    """Run a Google Search Grounding query.
+
+    Args:
+        query: Natural language query to send to Google Search Grounding.
+        top_k: Optional cap on the number of search results returned.
+        model: The Gemini model used for the underlying call.
+
+    Returns:
+        A dictionary containing ``results`` (list of dictionaries with
+        ``title``, ``url``, and ``snippet``) and ``grounding_metadata`` (raw
+        metadata for downstream use).
+
+    Raises:
+        GroundingSearchError: If the API key is missing, the query is empty,
+            or the Google API call fails.
+    """
+
+    if not query or not query.strip():
+        raise GroundingSearchError("Query must be a non-empty string.")
+
+    if top_k is not None and top_k <= 0:
+        raise GroundingSearchError("top_k must be a positive integer when provided.")
+
+    api_key = _ensure_api_key()
+
+    try:
+        generative_client = _configure_clients(api_key)
+    except Exception as exc:  # pragma: no cover - configuration errors are rare
+        raise GroundingSearchError(
+            "Failed to configure Google Generative AI client. "
+            "Please verify your GEMINI_API_KEY and local network settings."
+        ) from exc
+
+    request = glm.GenerateContentRequest(
+        model=model,
+        contents=[glm.Content(role="user", parts=[glm.Part(text=query.strip())])],
+        tools=[glm.Tool(google_search_retrieval=glm.GoogleSearchRetrieval())],
+        generation_config=glm.GenerationConfig(candidate_count=1, temperature=0.0),
+    )
+
+    try:
+        response = generative_client.generate_content(request=request)
+    except google_exceptions.Unauthenticated as exc:
+        raise GroundingSearchError(
+            "Authentication failed when calling Google Search Grounding. "
+            "Please confirm that GEMINI_API_KEY is correct and has Search "
+            "Grounding access enabled."
+        ) from exc
+    except google_exceptions.GoogleAPICallError as exc:
+        raise GroundingSearchError(
+            "Unable to reach Google Search Grounding. "
+            "Check your internet connection and ensure the Grounding API is available."
+        ) from exc
+    except Exception as exc:  # pragma: no cover
+        raise GroundingSearchError(
+            "An unexpected error occurred while querying Google Search Grounding."
+        ) from exc
+
+    metadata = getattr(response, "grounding_metadata", None)
+    results = _extract_results(metadata, top_k)
+    raw_metadata: Optional[Dict[str, Any]] = None
+
+    if metadata:
+        try:
+            raw_metadata = type(metadata).to_dict(metadata)
+        except Exception:  # pragma: no cover - fallback just keeps original object
+            raw_metadata = metadata  # type: ignore[assignment]
+
+    return {
+        "query": query.strip(),
+        "model": model,
+        "results": results,
+        "grounding_metadata": raw_metadata,
+    }


### PR DESCRIPTION
## Summary
- add a reusable `search_google_grounding` helper built on the Google Generative AI client with clear error messages and result parsing
- invoke the new search demo at the start of `main.py` and retain returned grounding metadata for later reuse
- extend the README with setup notes for Gemini API keys, Google Search Grounding access, and the local Ollama embedding service

## Testing
- python -m compileall src main.py

------
https://chatgpt.com/codex/tasks/task_e_68c893febce48333a219619e0ad15256