### PR TITLE
Handle invalid embeddings in diversity calculator

### DIFF
--- a/src/diversity_calculator.py
+++ b/src/diversity_calculator.py
@@ -11,18 +11,39 @@ def calculate_similarity_matrix(strategies: list[dict]) -> np.ndarray:
     Returns:
         A numpy.ndarray representing the N x N matrix of pairwise cosine
         similarities, where N is the number of strategies.
-        Returns an empty array if the input is invalid.
+        Returns an empty array if the input is invalid, contains empty embeddings,
+        or embeddings have inconsistent dimensions.
     """
     if not strategies or not all('embedding' in s for s in strategies):
         print("Error: Input is not a valid list of embedded strategies.")
         return np.array([])
 
-    # Extract the embedding vectors into a numpy array
-    embeddings = np.array([s['embedding'] for s in strategies])
+    embeddings_list = []
+    expected_dim = None
 
-    # Check for empty embeddings
-    if embeddings.size == 0:
-        return np.array([])
+    for index, strategy in enumerate(strategies):
+        embedding = np.array(strategy['embedding'], dtype=float).flatten()
+
+        if embedding.size == 0:
+            print(
+                "Error: Strategy at index"
+                f" {index} has an empty embedding. Returning empty similarity matrix."
+            )
+            return np.array([])
+
+        if expected_dim is None:
+            expected_dim = embedding.size
+        elif embedding.size != expected_dim:
+            print(
+                "Error: Strategy embeddings have inconsistent dimensions."
+                " Returning empty similarity matrix."
+            )
+            return np.array([])
+
+        embeddings_list.append(embedding)
+
+    # Extract the embedding vectors into a numpy array
+    embeddings = np.vstack(embeddings_list)
 
     # Normalize each vector to unit length. Add a small epsilon to avoid division by zero.
     norms = np.linalg.norm(embeddings, axis=1, keepdims=True)

--- a/tests/test_diversity_calculator.py
+++ b/tests/test_diversity_calculator.py
@@ -25,3 +25,29 @@ def test_calculate_similarity_matrix_with_valid_embeddings():
 def test_calculate_similarity_matrix_with_invalid_payload():
     assert calculate_similarity_matrix([]).size == 0
     assert calculate_similarity_matrix([{"no_embedding": []}]).size == 0
+
+
+def test_calculate_similarity_matrix_with_mismatched_dimensions(capfd):
+    strategies = [
+        {"embedding": [1.0, 0.0, 0.0]},
+        {"embedding": [0.0, 1.0]},
+    ]
+
+    matrix = calculate_similarity_matrix(strategies)
+
+    assert matrix.size == 0
+    captured = capfd.readouterr()
+    assert "inconsistent dimensions" in captured.out
+
+
+def test_calculate_similarity_matrix_with_empty_embedding(capfd):
+    strategies = [
+        {"embedding": []},
+        {"embedding": [1.0, 0.0, 0.0]},
+    ]
+
+    matrix = calculate_similarity_matrix(strategies)
+
+    assert matrix.size == 0
+    captured = capfd.readouterr()
+    assert "empty embedding" in captured.out


### PR DESCRIPTION
## Summary
- validate strategy embeddings in the diversity calculator to guard against empty or mismatched vectors
- document the defensive behavior in the similarity matrix helper
- cover empty and mismatched embeddings with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4fd7733448333aea742022bfd027b