### PR TITLE
Fix optional directory checks in Spec Kit scripts

### DIFF
--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -110,4 +110,17 @@ EOF
 }
 
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
-check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
+check_dir() {
+    if [[ -d "$1" ]]; then
+        local dir_contents
+        dir_contents=$(ls -A "$1" 2>/dev/null || true)
+
+        if [[ -n "$dir_contents" ]]; then
+            echo "  ✓ $2"
+        else
+            echo "  ✗ $2"
+        fi
+    else
+        echo "  ✗ $2"
+    fi
+}


### PR DESCRIPTION
## Summary
- add Spec Kit scaffolding including CLI config, VS Code settings, and prompt templates
- consolidate existing project rules into a new constitution with supporting spec, plan, and task documents
- document the Spec Kit workflow in the README to guide running `specify check`
- guard optional directory checks in `.specify/scripts/bash/common.sh` so `check-prerequisites.sh` doesn't abort when optional directories are absent

## Testing
- specify check
- bash .specify/scripts/bash/check-prerequisites.sh (fails on non-feature branch in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e67760e00c8333983d768e9f3366b7